### PR TITLE
D implementations, update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A benchmark to test different programming languages because I'm bored.
 - `rust-lang v1.55.0`
 - `typescript 4.4.3`
 - `java jdk16`
+- `D DMD`
+- `D LDC`
 - `<your_language_here>`
 
 ### Files:
@@ -13,6 +15,7 @@ The test file `img.raw` is a `920x404` raw image.
 It's 24 BPP (3 bytes per pixel), has `RGB` ordering and is interleaved (`R G B R G B ...`).  
 To read it you should use the `unsigned byte` type (e.g. `uint8_t`, `u8`, `byte` etc.).  
 You can open the raw images with [irfanview](https://www.irfanview.com/).
+If you are under Linux you can use [rawpixels.net](https://rawpixels.net/).
 
 Currently the test just reads the file to a buffer, creates a new buffer with the same length,  
 iterates over the source buffer in steps of 3 and copies the `RGB` values to the new buffer.  
@@ -27,11 +30,16 @@ The plan is to implement various image algorithms such as:
 
 ## Results:
 Run on a `AMD Ryzen 2600` at stock clocks.
+*Currently, the D implementations are not tested under the same circumstances as the other implementations.*
 
-| `lang` | `ms`  | `cmd` |
-| ------ | ----- | ----- |
-| `rust` | `0ms` | `cargo build --release && ./bin` |
-| `go`   | `0ms` | `go build && ./bin` |
-| `c#`   | `3ms` | `dotnet run` |
-| `ts`   | `4ms` | `ts-node` |
-| `java` | `6ms` | `javac && java` |
+| `lang`            | `ms`   | `cmd`                            |
+|-------------------|--------|----------------------------------|
+| `rust`            | `0ms`  | `cargo build --release && ./bin` |
+| `go`              | `0ms`  | `go build && ./bin`              |
+| `D DMD C-Style`   | `1ms`  | `dmd main.d && ./main`           |
+| `D LDC C-Style`   | `3ms`  | `ldc main.d && ./main`           |
+| `c#`              | `3ms`  | `dotnet run`                     |
+| `ts`              | `4ms`  | `ts-node`                        |
+| `java`            | `6ms`  | `javac && java`                  |
+| `D LDC C-Style`   | `17ms` | `ldc main.d && ./main`           |
+| `D DMD idiomatic` | `20ms` | `dmd main.d && ./main`           |

--- a/dlang/main.d
+++ b/dlang/main.d
@@ -1,0 +1,79 @@
+void main() {
+  idiomatic_image_copy(); // around 20 ms on my machine
+  og_image_copy(); // around 1 ms on my machine
+}
+
+void og_image_copy() {
+  import std.stdio;
+  import std.range;
+  import std.algorithm;
+  import std.datetime.stopwatch;
+
+  auto stopWatch = StopWatch(AutoStart.no);
+  
+  // Creating the file handle.
+  auto f = File("../img.raw", "r");
+  // Getting size of the file.
+  auto fileSize = f.size;
+  // Create buffer for file and reading it.
+  auto buff = f.rawRead(new ubyte[fileSize]);
+
+  // Somehow other benchmarks started the timer after the file is loaded,
+  // so do I now.
+  stopWatch.start();
+
+  // Create another empty buffer to copy the image to.
+  auto cpBuff = new ubyte[fileSize];
+
+  // OG iteration
+  for(int i = 0; i < fileSize; i += 3) {   
+    cpBuff[i]   =   buff[i];
+    cpBuff[i+1] = buff[i+1];
+    cpBuff[i+2] = buff[i+2];
+  }
+  // Stop the count!
+  stopWatch.stop();
+  
+  // Print timer result.
+  writefln("The OG image copy took: %d ms.", stopWatch.peek.total!"msecs"); 
+
+  // Write file to disk, so we can confirm everything went fine.
+  auto destFile = File("./img_dlang.raw", "w");
+  destFile.rawWrite(cpBuff);
+}
+
+void idiomatic_image_copy() {
+  import std.stdio;
+  import std.range;
+  import std.algorithm;
+  import std.datetime.stopwatch;
+
+  auto stopWatch = StopWatch(AutoStart.no);
+  
+  // Creating the file handle.
+  auto f = File("../img.raw", "r");
+  
+  // Getting size of the file.
+  auto fileSize = f.size;
+
+  // Create buffer for file and reading it.
+  auto buff = f.rawRead(new ubyte[fileSize]);
+
+  // Somehow other benchmarks started the timer after the file is loaded,
+  // so do I now.
+  stopWatch.start();
+
+  // Create another empty buffer to copy the image to.
+  // Slower, but more idiomatic.
+  ubyte[] cpBuff = [];
+  buff.slide(3,3).each!(rgb => cpBuff ~= rgb);
+  
+  // Stop the count!
+  stopWatch.stop();
+
+  writefln("The idiomatic image copy took: %d ms.", stopWatch.peek.total!"msecs");
+
+  // Write file to disk so we can confirm everything went fine.
+  auto destFile = File("./img_dlang.raw", "w");
+  destFile.rawWrite(cpBuff);
+}


### PR DESCRIPTION
Added two D implementations, one with the C like loop construct and one using ranges. Both a run with with the DMD and the LDC compiler. Added both of them to the table in the README.md, with the warning that they are not tested under the same circumstances as the other implementations because they ran on a different machine. Also added a note to the README.md that points to a website that can display raw image data.